### PR TITLE
ChatSpace　DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,40 @@ Things you may want to cover:
 
 * ...
 
+## user_groupテーブル
+
+|column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## messageテーブル
+
+|column|Type|Options|
+|------|----|-------|
+
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|content|string|
+|image|string|
+
+### Assosiation
+- belongs_to :group
+- belongs_to :user
+
+
+ ##usersテーブル
+
+|column|Type|Options|
+|------|----|-------|
+|name|string|null: false, add_index :users, :name, unique: true|
+|email|string|null: false, add_index :users, :email, unique: true|
+
+### Assosiation
+-has_meny :messages
+-has_many :user_group

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Things you may want to cover:
 
 * ...
 
-## user_groupテーブル
+## users_groupテーブル
 
 |column|Type|Options|
 |------|----|-------|
@@ -54,9 +54,19 @@ Things you may want to cover:
 
 |column|Type|Options|
 |------|----|-------|
-|name|string|null: false, add_index :users, :name, unique: true|
-|email|string|null: false, add_index :users, :email, unique: true|
+|name|string|null: false, index:true, unique: true|
+|email|string|null: false|
 
 ### Assosiation
 -has_meny :messages
 -has_many :user_group
+
+
+ ##groupsテーブル
+
+|column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+
+### Assosiation
+-has_many :messages

--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ Things you may want to cover:
 
 |column|Type|Options|
 |------|----|-------|
-
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
-|content|string|
-|image|string|
+|content|string|null: false, foreign_key: true|
+|image|string|null: false, foreign_key: true|
 
 ### Assosiation
 - belongs_to :group
@@ -55,11 +54,11 @@ Things you may want to cover:
 |column|Type|Options|
 |------|----|-------|
 |name|string|null: false, index:true, unique: true|
-|email|string|null: false|
+|email|string|null: false, unique: true|
 
 ### Assosiation
--has_meny :messages
--has_many :user_group
+- has_many :messages
+- has_many :user_group
 
 
  ##groupsテーブル
@@ -69,4 +68,4 @@ Things you may want to cover:
 |group_name|string|null: false|
 
 ### Assosiation
--has_many :messages
+- has_many :messages

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :group
+- belongs_to :groups
 - belongs_to :user
 
 
@@ -59,14 +59,15 @@ Things you may want to cover:
 
 ### Assosiation
 -has_meny :messages
--has_many :user_group
+-has_many :user_group, through: :users_group
 
 
  ##groupsテーブル
 
 |column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Assosiation
 -has_many :messages
+-has_many :users, through: :users_group

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
+|add_index :users_group, :user_id|
+|add_index :users_group, :group_id
 
 ### Association
 - belongs_to :group
@@ -19,8 +21,10 @@
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
-|content|string|null: false, foreign_key: true|
-|image|string|null: false, foreign_key: true|
+|content|string| foreign_key: true|
+|image|string| foreign_key: true|
+|add_index :message, :user_id|
+|add_index :message, :group_id|
 
 ### Assosiation
 - belongs_to :group
@@ -36,7 +40,7 @@
 
 ### Assosiation
 -has_meny :messages
--has_many :group, through: :users_group
+-has_many :users_groups, through: :users_group
 
 
  ##groupsテーブル
@@ -47,5 +51,5 @@
 
 ### Assosiation
 -has_many :messages
--has_many :users, through: :users_group
+-has_many :users, through: :users_groups
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,8 @@
 |email|string|null: false, unique: true|
 
 ### Assosiation
-<<<<<<< HEAD
 -has_meny :messages
 -has_many :user_group, through: :users_group
-=======
-- has_many :messages
-- has_many :user_group
->>>>>>> origin/作業用
 
 
  ##groupsテーブル
@@ -51,9 +46,6 @@
 |name|string|null: false|
 
 ### Assosiation
-<<<<<<< HEAD
 -has_many :messages
 -has_many :users, through: :users_group
-=======
-- has_many :messages
->>>>>>> origin/作業用
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :groups
+- belongs_to :group
 - belongs_to :user
 
 
@@ -36,14 +36,14 @@
 
 ### Assosiation
 -has_meny :messages
--has_many :user_group, through: :users_group
+-has_many :group, through: :users_group
 
 
  ##groupsテーブル
 
 |column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
+|name|string|null: false, index:true, unique: true|
 
 ### Assosiation
 -has_many :messages


### PR DESCRIPTION
WHAT Readme.mdにDB設計、テーブルの内容とアソシエーションを記述。 WHY
Chatspace実装前に必要なテーブルやカラム、テーブル同士の関係性を明確にするため。